### PR TITLE
Fix the provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
         }
     },
     "provide": {
-        "psr/simple-cache-implementation": "^1.0"
+        "psr/simple-cache-implementation": "1.0"
     }
 }


### PR DESCRIPTION
The current codebase (tries to) provide an implementation of simple-cache 1.0. It cannot guarantee that it provides an implementation of simple-cache 1.1 as there is no such spec yet.

`When using ``provide`` for an implementation package, using a semver operator is always wrong. It should either be an exact version (most common case) or a range where the **upper** bound is the version used as reference of the implementation (I'm not sure it makes much sense to say that you implement older implementations at the same time though, so the rule may even be better as ``always exact``)