### PR TITLE
Storing `false` in cache should return `false`

### DIFF
--- a/src/SimpleCacheAdapter.php
+++ b/src/SimpleCacheAdapter.php
@@ -84,6 +84,11 @@ final class SimpleCacheAdapter implements PsrCache
 
         $value = $this->doctrineCache->fetch($key);
         if ($value === false) {
+            // Doctrine cache returns `false` when cache doesn't contain, but also `false` if the value stored is
+            // `false`, so check to see if the cache contains the key; if so, we probably meant to return `false`
+            if ($this->doctrineCache->contains($key)) {
+                return false;
+            }
             return $default;
         }
 

--- a/test/unit/CacheIntegrationTest.php
+++ b/test/unit/CacheIntegrationTest.php
@@ -31,7 +31,6 @@ final class CacheIntegrationTest extends SimpleCacheTest
         $this->skippedTests['testSetMultipleNoIterable'] = true;
         $this->skippedTests['testDeleteMultipleNoIterable'] = true;
         $this->skippedTests['testObjectDoesNotChangeInCache'] = true;
-        $this->skippedTests['testDataTypeBoolean'] = true;
 
         // https://github.com/php-cache/integration-tests/pull/74/files
         $this->skippedTests['testSetMultiple'] = true;

--- a/test/unit/SimpleCacheAdapterTest.php
+++ b/test/unit/SimpleCacheAdapterTest.php
@@ -120,6 +120,16 @@ final class SimpleCacheAdapterTest extends \PHPUnit_Framework_TestCase
         self::assertSame($default, $psrCache->get($anotherKey, $default));
     }
 
+    public function testGetWithFalseValueStoredInCache()
+    {
+        $key = uniqid('key', true);
+
+        $psrCache = new SimpleCacheAdapter(new ArrayCache());
+        $psrCache->set($key, false);
+
+        self::assertFalse($psrCache->get($key, uniqid('default', true)));
+    }
+
     public function testSetProxiesToDoctrineSave()
     {
         $key = uniqid('key', true);


### PR DESCRIPTION
Implement integration test storing `false` value in the cache returns the false value. Doctrine Cache returns `false` when the value is not in the cache, so I added a check if the returned key is actually in the cache. Not 100% convinced on this solution (maybe loses some atomicity? what if the key didn't exist on the `fetch` call, but then does on the `contains` call?) but I'm not sure of another way around it.

This forms another part of implementing #8.