### PR TITLE
Require PHPUnit 6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "cache/integration-tests": "^0.15.0",
+        "cache/integration-tests": "dev-master",
         "cache/tag-interop": "^1.0@dev",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "humbug/humbug": "~1.0@dev"
     },
     "license": "MIT",

--- a/test/unit/Exception/CacheExceptionTest.php
+++ b/test/unit/Exception/CacheExceptionTest.php
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace RoaveTest\DoctrineSimpleCache\Exception;
 
 use Doctrine\Common\Cache\Cache as DoctrineCache;
+use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheException as PsrCacheException;
 use Roave\DoctrineSimpleCache\Exception\CacheException;
 
 /**
  * @covers \Roave\DoctrineSimpleCache\Exception\CacheException
  */
-final class CacheExceptionTest extends \PHPUnit_Framework_TestCase
+final class CacheExceptionTest extends TestCase
 {
     public function testFromNonClearableCache()
     {

--- a/test/unit/Exception/InvalidArgumentExceptionTest.php
+++ b/test/unit/Exception/InvalidArgumentExceptionTest.php
@@ -4,12 +4,13 @@ declare(strict_types = 1);
 namespace RoaveTest\DoctrineSimpleCache\Exception;
 
 use Roave\DoctrineSimpleCache\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
 
 /**
  * @covers \Roave\DoctrineSimpleCache\Exception\InvalidArgumentException
  */
-final class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+final class InvalidArgumentExceptionTest extends TestCase
 {
     public function testFromKeyAndInvalidTTLObject()
     {

--- a/test/unit/SimpleCacheAdapterTest.php
+++ b/test/unit/SimpleCacheAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace RoaveTest\DoctrineSimpleCache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use PHPUnit\Framework\TestCase;
 use Roave\DoctrineSimpleCache\Exception\CacheException;
 use Roave\DoctrineSimpleCache\Exception\InvalidArgumentException;
 use Roave\DoctrineSimpleCache\SimpleCacheAdapter;
@@ -15,7 +16,7 @@ use RoaveTestAsset\DoctrineSimpleCache\NotMultiPuttableCache;
 /**
  * @covers \Roave\DoctrineSimpleCache\SimpleCacheAdapter
  */
-final class SimpleCacheAdapterTest extends \PHPUnit_Framework_TestCase
+final class SimpleCacheAdapterTest extends TestCase
 {
     public function invalidTTLs() : array
     {


### PR DESCRIPTION
Not enough for https://github.com/Roave/DoctrineSimpleCache/pull/21 to pass, but still needed.

`cache/integration-tests` has no release with PHPUnit 6.5 support, need `dev-master` for now.