### PR TITLE
Use correct exception named constructor when creating SimpleCacheAdapter with a non-Clearable cache

### DIFF
--- a/src/SimpleCacheAdapter.php
+++ b/src/SimpleCacheAdapter.php
@@ -25,7 +25,7 @@ final class SimpleCacheAdapter implements PsrCache
         $this->doctrineCache = $doctrineCache;
 
         if (!$this->doctrineCache instanceof ClearableCache) {
-            throw Exception\CacheException::fromNonMultiOperationCache($this->doctrineCache);
+            throw Exception\CacheException::fromNonClearableCache($this->doctrineCache);
         }
 
         if (!$this->doctrineCache instanceof MultiOperationCache) {

--- a/test/unit/SimpleCacheAdapterTest.php
+++ b/test/unit/SimpleCacheAdapterTest.php
@@ -71,6 +71,7 @@ final class SimpleCacheAdapterTest extends TestCase
         $doctrineCache = $this->createMock(NotMultiOperationCache::class);
 
         $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('not support multiple operations');
         new SimpleCacheAdapter($doctrineCache);
     }
 
@@ -80,6 +81,7 @@ final class SimpleCacheAdapterTest extends TestCase
         $doctrineCache = $this->createMock(NotClearableCache::class);
 
         $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('not clearable');
         new SimpleCacheAdapter($doctrineCache);
     }
 


### PR DESCRIPTION
Fixes #25 