### PR TITLE
Update infection to 0.9.3 and remove workaround

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
         "cache/integration-tests": "dev-master#ff86c07073a5d6b7a7fe9019dd4f6d8fdaaca5ea",
         "cache/tag-interop": "^1.0@dev",
         "phpunit/phpunit": "^6.5",
-        "infection/infection": "^0.9.2",
-        "symfony/console": "^3.4"
+        "infection/infection": "^0.9.3"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Infection 0.9.3 fixed the symfony 3.2 compatibility, thus removing the need for the `"symfony/console": "^3.4"` work around.

See also https://github.com/infection/infection/pull/437