### PR TITLE
Support PHP 7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Doctrine Cache adapter for PSR-16 Simple Cache",
     "type": "library",
     "require": {
-        "php": "~7.1.0 || ~7.2.0",
+        "php": ">=7.1.0 <7.4",
         "doctrine/cache": "^1.7",
         "psr/simple-cache": "^1.0"
     },


### PR DESCRIPTION
This commit allows PHP 7.3 as a valid PHP version for this package and enables it for testing in Travis. I've run the tests locally and everything still seems to work.