### PR TITLE
Conditionally set BC alias to support PHP 7.4+ preloading semantics 

### DIFF
--- a/namespace-bc-aliases.php
+++ b/namespace-bc-aliases.php
@@ -1,3 +1,5 @@
 <?php
 
-class_alias(\Roave\DoctrineSimpleCache\Exception\CacheException::class, \Roave\DoctrineSimpleCache\CacheException::class);
+if (!class_exists(\Roave\DoctrineSimpleCache\CacheException::class, false)) {
+    class_alias(\Roave\DoctrineSimpleCache\Exception\CacheException::class, \Roave\DoctrineSimpleCache\CacheException::class);
+}


### PR DESCRIPTION
Only set alias if not yet exists to aid preloading scenarios where the BC aliases have been defined during preloading already and should not be redefined.